### PR TITLE
[MODULAR] Cell Charging for Synths

### DIFF
--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -6,13 +6,13 @@
 #define SYNTH_APC_MINIMUM_PERCENT 20
 
 /obj/item/organ/internal/cyberimp/arm/power_cord
-	name = "power cord implant"
+	name = "charging implant"
 	desc = "An internal power cord. Useful if you run on elecricity. Not so much otherwise."
-	contents = newlist(/obj/item/apc_powercord)
+	contents = newlist(/obj/item/synth_powercord)
 	zone = "l_arm"
 	cannot_confiscate = TRUE
 
-/obj/item/apc_powercord
+/obj/item/synth_powercord
 	name = "power cord"
 	desc = "An internal power cord. Useful if you run on electricity. Not so much otherwise."
 	icon = 'icons/obj/stack_objects.dmi'
@@ -24,24 +24,24 @@
 	))
 
 ///Attempt to charge from an object by using them on the powercord.
-/obj/item/apc_powercord/attackby(obj/item/attacking_item, mob/user, params)
+/obj/item/synth_powercord/attackby(obj/item/attacking_item, mob/user, params)
 	if(!can_power_draw(attacking_item, user))
 		return ..()
 	try_power_draw(attacking_item, user)
 
 ///Attempt to charge from an object by using the powercord on them.
-/obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/synth_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag || !can_power_draw(target, user))
 		return ..()
 	try_power_draw(target, user)
 
 ///Returns TRUE or FALSE depending on if the target object can be used as a power source.
-/obj/item/apc_powercord/proc/can_power_draw(obj/target, mob/user)
+/obj/item/synth_powercord/proc/can_power_draw(obj/target, mob/user)
 	return ishuman(user) && is_type_in_typecache(target, synth_charge_whitelist)
 
 ///Attempts to start using an object as a power source.
 ///Checks the user's internal powercell to see if it exists.
-/obj/item/apc_powercord/proc/try_power_draw(obj/target, mob/living/carbon/human/user)
+/obj/item/synth_powercord/proc/try_power_draw(obj/target, mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	var/obj/item/organ/internal/stomach/synth/synth_cell = user.get_organ_slot(ORGAN_SLOT_STOMACH)
@@ -74,7 +74,7 @@
  * * target - The power cell or APC to drain.
  * * user - The human mob draining the power cell.
  */
-/obj/item/apc_powercord/proc/do_power_draw(obj/target, mob/living/carbon/human/user)
+/obj/item/synth_powercord/proc/do_power_draw(obj/target, mob/living/carbon/human/user)
 	// Draw power from an APC if one was given.
 	var/obj/machinery/power/apc/target_apc
 	if(istype(target, /obj/machinery/power/apc))

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -56,11 +56,11 @@
 	var/obj/item/organ/internal/stomach/synth/synth_cell = ipc.organs_slot[ORGAN_SLOT_STOMACH]
 
 	if(!synth_cell)
-		to_chat(ipc, span_warning("You try to siphon energy from the [target], but you have no stomach! How are you still standing?"))
+		to_chat(ipc, span_warning("You try to siphon energy from [target], but you have no stomach! How are you still standing?"))
 		return
 
 	if(!istype(synth_cell))
-		to_chat(ipc, span_warning("You plug into the [target], but nothing happens! It seems you don't have a cell to charge!"))
+		to_chat(ipc, span_warning("You plug into [target], but nothing happens! It seems you don't have a cell to charge!"))
 		return
 
 	if(target_cell.percent() < SYNTH_APC_MINIMUM_PERCENT)
@@ -71,9 +71,9 @@
 		to_chat(user, span_warning("You are already fully charged!"))
 		return
 
-	user.visible_message(span_notice("[user] inserts a power connector into the [target]."), span_notice("You begin to draw power from the [target]."))
+	user.visible_message(span_notice("[user] inserts a power connector into [target]."), span_notice("You begin to draw power from [target]."))
 	powerdraw_loop(target_cell, ipc)
-	user.visible_message(span_notice("[user] unplugs from the [target]."), span_notice("You unplug from the [target]."))
+	user.visible_message(span_notice("[user] unplugs from [target]."), span_notice("You unplug from [target]."))
 
 	if(target_apc && target_apc.main_status <= APC_HAS_POWER)
 		target_apc.charging = APC_CHARGING

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -23,83 +23,73 @@
 		/obj/machinery/power/apc,
 	))
 
+///Attempt to charge from an object by using them on the powercord.
 /obj/item/apc_powercord/attackby(obj/item/attacking_item, mob/user, params)
 	if(!can_power_draw(attacking_item, user))
 		return ..()
-	power_draw(attacking_item, user)
+	try_power_draw(attacking_item, user)
 
+///Attempt to charge from an object by using the powercord on them.
 /obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag || !can_power_draw(target, user))
 		return ..()
-	power_draw(target, user)
+	try_power_draw(target, user)
 
-/obj/item/apc_powercord/proc/can_power_draw(obj/target, mob/living/carbon/human/user)
+///Returns TRUE or FALSE depending on if the target object can be used as a power source.
+/obj/item/apc_powercord/proc/can_power_draw(obj/target, mob/user)
 	return ishuman(user) && is_type_in_typecache(target, charge_whitelist)
 
-/obj/item/apc_powercord/proc/power_draw(obj/target, mob/living/carbon/human/user)
+///Attempts to start using an object as a power source.
+///Checks the user's internal powercell to see if it exists.
+/obj/item/apc_powercord/proc/try_power_draw(obj/target, mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 
-	var/obj/item/stock_parts/cell/target_cell
-	var/obj/machinery/power/apc/target_apc
-
-	if(istype(target, /obj/machinery/power/apc))
-		target_apc = target
-		target_cell = target_apc.cell
-	else
-		target_cell = target
-
-	if(target_apc && !target_cell)
-		to_chat(user, span_warning("[target] has no charge to draw from."))
-		return
-		
-	var/mob/living/carbon/human/ipc = user
-	var/obj/item/organ/internal/stomach/synth/synth_cell = ipc.organs_slot[ORGAN_SLOT_STOMACH]
-
-	if(!synth_cell)
-		to_chat(ipc, span_warning("You try to siphon energy from [target], but you have no stomach! How are you still standing?"))
+	var/obj/item/organ/internal/stomach/synth/synth_cell = user.organs_slot[ORGAN_SLOT_STOMACH]
+	if(QDELETED(synth_cell) || !istype(synth_cell))
+		to_chat(user, span_warning("You plug into [target], but nothing happens! It seems you don't have an internal cell to charge."))
 		return
 
-	if(!istype(synth_cell))
-		to_chat(ipc, span_warning("You plug into [target], but nothing happens! It seems you don't have a cell to charge!"))
-		return
-
-	if(target_cell.percent() < SYNTH_APC_MINIMUM_PERCENT)
-		to_chat(user, span_warning("[target] has no charge to draw from."))
-		return
-
-	if(ipc.nutrition >= NUTRITION_LEVEL_ALMOST_FULL)
+	if(user.nutrition >= NUTRITION_LEVEL_ALMOST_FULL)
 		to_chat(user, span_warning("You are already fully charged!"))
 		return
 
 	user.visible_message(span_notice("[user] inserts a power connector into [target]."), span_notice("You begin to draw power from [target]."))
-	powerdraw_loop(target_cell, ipc)
+	do_power_draw(target, user)
+
+	if(QDELETED(target))
+		return
+
 	user.visible_message(span_notice("[user] unplugs from [target]."), span_notice("You unplug from [target]."))
 
-	if(target_apc && target_apc.main_status <= APC_HAS_POWER)
-		target_apc.charging = APC_CHARGING
-		target_apc.update_appearance()
-
 /**
- * Runs a loop to charge a synth cell (stomach) via powercord from a APC or power cell.
+ * Runs a loop to charge a synth cell (stomach) from a power cell or APC.
+ * Displays chat messages to the user and nearby observers.
  *
  * Stops when:
  * - The user's internal cell is full.
- * - The APC or cell has less than 20% charge.
- * - The APC has machine power turned off.
- * - The APC is unable to provide charge for any other reason.
+ * - The cell has less than the minimum charge.
  * - The user moves, or anything else that can happen to interrupt a do_after.
  *
  * Arguments:
- * * target_apc - The APC to drain.
- * * user - The carbon draining the APC.
+ * * target - The power cell or APC to drain.
+ * * user - The human mob draining the power cell.
  */
-/obj/item/apc_powercord/proc/powerdraw_loop(obj/item/stock_parts/cell/target_cell, mob/living/carbon/human/user)
+/obj/item/apc_powercord/proc/do_power_draw(obj/target, mob/living/carbon/human/user)
+	// Draw power from an APC if one was given.
+	var/obj/machinery/power/apc/target_apc
+	if(istype(target, /obj/machinery/power/apc))
+		target_apc = target
+
+	var/obj/item/stock_parts/cell/target_cell = target_apc ? target_apc.cell : target
+	var/minimum_cell_charge = target_apc ? SYNTH_APC_MINIMUM_PERCENT : 0
+
+	if(!target_cell || target_cell.percent() < minimum_cell_charge)
+		to_chat(user, span_warning("[target] has no charge to draw from."))
+		return
+
 	var/power_needed
 	var/power_use
 	while(TRUE)
-		if(QDELETED(target_cell))
-			return
-
 		// Check if the user is "fully charged" yet.
 		// Ensures minimum draw is always lower than this margin to prevent wasteful loops.
 		power_needed = NUTRITION_LEVEL_ALMOST_FULL - user.nutrition
@@ -107,24 +97,38 @@
 			to_chat(user, span_notice("You are fully charged."))
 			break
 
-		// Check if the charge level of the cell is low.
-		// 20%, to prevent synths from overstepping and murdering power for department machines and potentially doors.
-		if(target_cell.percent() < SYNTH_APC_MINIMUM_PERCENT)
-			to_chat(user, span_warning("[target_cell]'s power is too low to charge you."))
+		// Check if the charge level of the cell is below the minimum.
+		// Prevents synths from overloading the cell.
+		if(target_cell.percent() < minimum_cell_charge)
+			to_chat(user, span_warning("[target] lacks the power to charge you."))
 			break
 
 		// Calculate how much to draw from the cell this cycle.
 		power_use = clamp(power_needed, SYNTH_CHARGE_MIN, SYNTH_CHARGE_MAX)
 		power_use = clamp(power_use, 0, target_cell.charge)
 		if(power_use <= 0)
-			to_chat(user, span_warning("[target_cell] lacks the power to charge you."))
+			to_chat(user, span_warning("[target] lacks the power to charge you."))
 			break
 
-		// Drain charge from the cell, increase user nutrition, and emit sparks.
-		do_after(user, (power_use / 100) * SYNTH_CHARGE_DELAY_PER_100, target_cell)
-		target_cell.use(power_use)
+		// Attempt to drain charge from the cell.
+		if(!do_after(user, (power_use / 100) * SYNTH_CHARGE_DELAY_PER_100, target))
+			break
+
+		if(!target_cell.use(power_use))
+			// The cell could be sabotaged, which causes it to explode and qdelete.
+			if(QDELETED(target_cell))
+				return
+			to_chat(user, span_warning("[target] lacks the power to charge you."))
+			break
+
+		// If charging was successful, then increase user nutrition and emit sparks.
 		user.nutrition += power_use / SYNTH_CHARGE_PER_NUTRITION
 		do_sparks(1, FALSE, target_cell.loc)
+
+	// Start APC recharging if power was used and the APC has power available.
+	if(target_apc && !QDELETED(target_apc) && !QDELETED(target_apc.cell) && target_apc.main_status > APC_NO_POWER)
+		target_apc.charging = APC_CHARGING
+		target_apc.update_appearance()
 
 #undef SYNTH_CHARGE_MAX
 #undef SYNTH_CHARGE_MIN

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -17,40 +17,72 @@
 	desc = "An internal power cord. Useful if you run on electricity. Not so much otherwise."
 	icon = 'icons/obj/stack_objects.dmi'
 	icon_state = "wire1"
+	///Object basetypes which the powercord is allowed to connect to.
+	var/static/list/charge_whitelist = typecacheof(list(
+		/obj/item/stock_parts/cell,
+		/obj/machinery/power/apc,
+	))
 
-/obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	if(!istype(target, /obj/machinery/power/apc) || !ishuman(user) || !proximity_flag)
+///Connects to a power cell.
+/obj/item/apc_powercord/attackby(obj/item/item, mob/living/user, params)
+	if(istype(item, /obj/item/stock_parts/cell))
+		power_draw(item, user)
+	else
 		return ..()
 
+/obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	if(!ishuman(user) || !proximity_flag || !is_type_in_typecache(target, charge_whitelist))
+		return ..()
 	user.changeNext_move(CLICK_CD_MELEE)
-	var/obj/machinery/power/apc/target_apc = target
+	power_draw(target, user)
+
+/obj/item/apc_powercord/proc/power_draw(obj/target, mob/living/carbon/human/user)
+	var/obj/item/stock_parts/cell/target_cell
+	var/obj/machinery/power/apc/target_apc
+
+	if(istype(target, /obj/machinery/power/apc))
+		target_apc = target
+		target_cell = target_apc.cell
+	else
+		target_cell = target
+
+	if(target_apc && !target_cell)
+		to_chat(user, span_warning("[target] has no charge to draw from."))
+		return
+		
 	var/mob/living/carbon/human/ipc = user
-	var/obj/item/organ/internal/stomach/synth/cell = ipc.organs_slot[ORGAN_SLOT_STOMACH]
+	var/obj/item/organ/internal/stomach/synth/synth_cell = ipc.organs_slot[ORGAN_SLOT_STOMACH]
 
-	if(!cell)
-		to_chat(ipc, span_warning("You try to siphon energy from the [target_apc], but you have no stomach! How are you still standing?"))
+	if(!synth_cell)
+		to_chat(ipc, span_warning("You try to siphon energy from the [target], but you have no stomach! How are you still standing?"))
 		return
 
-	if(!istype(cell))
-		to_chat(ipc, span_warning("You plug into the APC, but nothing happens! It seems you don't have a cell to charge!"))
+	if(!istype(synth_cell))
+		to_chat(ipc, span_warning("You plug into the [target], but nothing happens! It seems you don't have a cell to charge!"))
 		return
 
-	if(target_apc.cell && target_apc.cell.percent() < SYNTH_APC_MINIMUM_PERCENT)
-		to_chat(user, span_warning("There is no charge to draw from that APC."))
+	if(target_cell.percent() < SYNTH_APC_MINIMUM_PERCENT)
+		to_chat(user, span_warning("[target] has no charge to draw from."))
 		return
 
 	if(ipc.nutrition >= NUTRITION_LEVEL_ALMOST_FULL)
 		to_chat(user, span_warning("You are already fully charged!"))
 		return
 
-	powerdraw_loop(target_apc, ipc)
+	user.visible_message(span_notice("[user] inserts a power connector into the [target]."), span_notice("You begin to draw power from the [target]."))
+	powerdraw_loop(target_cell, ipc)
+	user.visible_message(span_notice("[user] unplugs from the [target]."), span_notice("You unplug from the [target]."))
+
+	if(target_apc && target_apc.main_status <= APC_HAS_POWER)
+		target_apc.charging = APC_CHARGING
+		target_apc.update_appearance()
 
 /**
- * Runs a loop to charge a synth cell (stomach) via powercord from an APC.
+ * Runs a loop to charge a synth cell (stomach) via powercord from a APC or power cell.
  *
  * Stops when:
- * - The user is full.
- * - The APC has less than 20% charge.
+ * - The user's internal cell is full.
+ * - The APC or cell has less than 20% charge.
  * - The APC has machine power turned off.
  * - The APC is unable to provide charge for any other reason.
  * - The user moves, or anything else that can happen to interrupt a do_after.
@@ -59,47 +91,41 @@
  * * target_apc - The APC to drain.
  * * user - The carbon draining the APC.
  */
-/obj/item/apc_powercord/proc/powerdraw_loop(obj/machinery/power/apc/target_apc, mob/living/carbon/human/user)
-	user.visible_message(span_notice("[user] inserts a power connector into the [target_apc]."), span_notice("You begin to draw power from the [target_apc]."))
-
+/obj/item/apc_powercord/proc/powerdraw_loop(obj/item/stock_parts/cell/target_cell, mob/living/carbon/human/user)
+	var/power_needed
+	var/power_delay
+	var/power_use
 	while(TRUE)
-		var/power_needed = NUTRITION_LEVEL_ALMOST_FULL - user.nutrition // How much charge do we need in total?
-		// Do we even need anything?
-		if(power_needed <= SYNTH_CHARGE_MIN * 2) // Times two to make sure minimum draw is always lower than this margin to prevent potential needless loops.
+		if(QDELETED(target_cell))
+			return
+
+		// Check if the user is "fully charged" yet.
+		// Ensures minimum draw is always lower than this margin to prevent wasteful loops.
+		power_needed = NUTRITION_LEVEL_ALMOST_FULL - user.nutrition
+		if(power_needed <= SYNTH_CHARGE_MIN * 2)
 			to_chat(user, span_notice("You are fully charged."))
 			break
 
-		// Is the APC not charging equipment? And yes, synths are gonna be treated as equipment. Deal with it.
-		if(target_apc.cell.percent() < SYNTH_APC_MINIMUM_PERCENT) // 20%, to prevent synths from overstepping and murdering power for department machines and potentially doors.
-			to_chat(user, span_warning("[target_apc]'s power is too low to charge you."))
+		// Check if the charge level of the cell is low.
+		// 20%, to prevent synths from overstepping and murdering power for department machines and potentially doors.
+		if(target_cell.percent() < SYNTH_APC_MINIMUM_PERCENT)
+			to_chat(user, span_warning("[target_cell]'s power is too low to charge you."))
 			break
 
-		// Calculate how much to draw this cycle
-		var/power_use = clamp(power_needed, SYNTH_CHARGE_MIN, SYNTH_CHARGE_MAX)
-		power_use = clamp(power_use, 0, target_apc.cell.charge)
-		// Are we able to draw anything?
+		// Calculate how much to draw from the cell this cycle.
+		power_use = clamp(power_needed, SYNTH_CHARGE_MIN, SYNTH_CHARGE_MAX)
+		power_use = clamp(power_use, 0, target_cell.charge)
 		if(power_use <= 0)
-			to_chat(user, span_warning("[target_apc] lacks the power to charge you."))
+			to_chat(user, span_warning("[target_cell] lacks the power to charge you."))
 			break
 
-		// Calculate the delay.
-		var/power_delay = (power_use / 100) * SYNTH_CHARGE_DELAY_PER_100
-		// Attempt to run a charging cycle.
-		if(!do_after(user, power_delay, target = target_apc))
-			break
-
-		// Use the power and increase nutrition.
-		target_apc.cell.use(power_use)
-
+		// Drain charge from the cell, increase user nutrition, and emit sparks.
+		do_after(user, power_delay, target_cell)
+		target_cell.use(power_use)
 		user.nutrition += power_use / SYNTH_CHARGE_PER_NUTRITION
-		do_sparks(1, FALSE, target_apc)
+		do_sparks(1, FALSE, target_cell.loc)
 
-	if(target_apc.main_status <= APC_HAS_POWER)
-		target_apc.charging = APC_CHARGING
-		target_apc.update_appearance()
-	else
-		return
-	user.visible_message(span_notice("[user] unplugs from the [target_apc]."), span_notice("You unplug from the [target_apc]."))
+		power_delay = (power_use / 100) * SYNTH_CHARGE_DELAY_PER_100
 
 #undef SYNTH_CHARGE_MAX
 #undef SYNTH_CHARGE_MIN

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -23,20 +23,22 @@
 		/obj/machinery/power/apc,
 	))
 
-///Connects to a power cell.
-/obj/item/apc_powercord/attackby(obj/item/item, mob/living/user, params)
-	if(istype(item, /obj/item/stock_parts/cell))
-		power_draw(item, user)
-	else
+/obj/item/apc_powercord/attackby(obj/item/attacking_item, mob/user, params)
+	if(!can_power_draw(attacking_item, user))
 		return ..()
+	power_draw(attacking_item, user)
 
 /obj/item/apc_powercord/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	if(!ishuman(user) || !proximity_flag || !is_type_in_typecache(target, charge_whitelist))
+	if(!proximity_flag || !can_power_draw(target, user))
 		return ..()
-	user.changeNext_move(CLICK_CD_MELEE)
 	power_draw(target, user)
 
+/obj/item/apc_powercord/proc/can_power_draw(obj/target, mob/living/carbon/human/user)
+	return ishuman(user) && is_type_in_typecache(target, charge_whitelist)
+
 /obj/item/apc_powercord/proc/power_draw(obj/target, mob/living/carbon/human/user)
+	user.changeNext_move(CLICK_CD_MELEE)
+
 	var/obj/item/stock_parts/cell/target_cell
 	var/obj/machinery/power/apc/target_apc
 

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -44,7 +44,7 @@
 /obj/item/apc_powercord/proc/try_power_draw(obj/target, mob/living/carbon/human/user)
 	user.changeNext_move(CLICK_CD_MELEE)
 
-	var/obj/item/organ/internal/stomach/synth/synth_cell = user.organs_slot[ORGAN_SLOT_STOMACH]
+	var/obj/item/organ/internal/stomach/synth/synth_cell = user.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(QDELETED(synth_cell) || !istype(synth_cell))
 		to_chat(user, span_warning("You plug into [target], but nothing happens! It seems you don't have an internal cell to charge."))
 		return

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -95,7 +95,6 @@
  */
 /obj/item/apc_powercord/proc/powerdraw_loop(obj/item/stock_parts/cell/target_cell, mob/living/carbon/human/user)
 	var/power_needed
-	var/power_delay
 	var/power_use
 	while(TRUE)
 		if(QDELETED(target_cell))
@@ -122,12 +121,10 @@
 			break
 
 		// Drain charge from the cell, increase user nutrition, and emit sparks.
-		do_after(user, power_delay, target_cell)
+		do_after(user, (power_use / 100) * SYNTH_CHARGE_DELAY_PER_100, target_cell)
 		target_cell.use(power_use)
 		user.nutrition += power_use / SYNTH_CHARGE_PER_NUTRITION
 		do_sparks(1, FALSE, target_cell.loc)
-
-		power_delay = (power_use / 100) * SYNTH_CHARGE_DELAY_PER_100
 
 #undef SYNTH_CHARGE_MAX
 #undef SYNTH_CHARGE_MIN

--- a/modular_nova/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_nova/modules/synths/code/bodyparts/power_cord.dm
@@ -18,7 +18,7 @@
 	icon = 'icons/obj/stack_objects.dmi'
 	icon_state = "wire1"
 	///Object basetypes which the powercord is allowed to connect to.
-	var/static/list/charge_whitelist = typecacheof(list(
+	var/static/list/synth_charge_whitelist = typecacheof(list(
 		/obj/item/stock_parts/cell,
 		/obj/machinery/power/apc,
 	))
@@ -37,7 +37,7 @@
 
 ///Returns TRUE or FALSE depending on if the target object can be used as a power source.
 /obj/item/apc_powercord/proc/can_power_draw(obj/target, mob/user)
-	return ishuman(user) && is_type_in_typecache(target, charge_whitelist)
+	return ishuman(user) && is_type_in_typecache(target, synth_charge_whitelist)
 
 ///Attempts to start using an object as a power source.
 ///Checks the user's internal powercell to see if it exists.


### PR DESCRIPTION
## About The Pull Request

This PR is a deliverable for a bounty. Most of the bounty was implemented except for visual attachment.

The changes included in this PR enables the "power cord implant" to directly charge from power cells.

- Added a static typecache `synth_charge_whitelist` for easily whitelisting of objects/cells to be used for charging.
- Added power cell compatibility to the existing code by re-writing it to be more ubiquitous.
- Refactored `/obj/item/apc_powercord` significantly and repathed it to `/obj/item/synth_powercord`.
- Renamed `/obj/item/organ/internal/cyberimp/arm/power_cord` from "power cord implant" to "charging implant".
- Added hard-delete protection in `/obj/item/apc_powercord` in case the cell was rigged to explode.

## How This Contributes To The Nova Sector Roleplay Experience

### Bounty Descriptuon

>"Unlocks the space-age technology of inductive-charging for our synthetic humanoids. This would be adding functionality to the power-cord implant to function on cells outside of an APC (stealing some functionality from Ethereals, who can already do this). The implant would thus be renamed to "Charging Implant" instead, and would require a minor sprite update so that the cell looks visually attached to the cord when draining power from it, in-hand (mob sprite change not required here).
>
>This would be beneficial for Synthetic Humanoids who usually don't leave their workplace often and max out the room's APC rather quickly, and Synthetics carrying around batteries to snack on is very flavorful - not to mention very helpful for synthetic miners."

<summary>Testimony from Lieutenant Commander Data</summary>
<details>

>"I initiated the testing process as per your instructions. Commencing with the connection to a standard power cell, followed by testing with an EPS conduit's inverter. I monitored the energy transfer, automatic disconnection, and subsequent internal power cell charge.
>
> Connection to a standard power cell was successful. The power cord effectively received energy, and the automatic disconnection mechanism engaged as the minimum energy level was reached. Subsequently, my internal power cell was observed to have increased to its maximum level. Testing with an EPS conduit's inverter also yielded positive results. The power cord efficiently interfaced with the inverter, underwent the automatic disconnection process upon reaching the minimum energy level, and successfully increased the internal power cell charge to its maximum level.
>
>The implant appears to function as intended, demonstrating reliability and safety. The new power cord implant offers a more direct and efficient method of energy transfer, minimizing downtime for recharging. Prior to the new design, I relied on traditional charging methods, often requiring a dedicated charging station. The new implant enhances my operational efficiency by allowing for on-the-go charging, which aligns with the principles of productivity and adaptability.
>
> Given the positive results of the testing and the potential operational benefits, I would cautiously recommend the implant to other synthetic life forms. I trust that the information I have provided will be valuable in Nanotrasen's decision-making process. If there are further inquiries or if additional assistance is required, please do not hesitate to contact me.
>
>Respectfully,
>Lieutenant Commander Data,
>United Federation of Planets, Starfleet

</details>

## Proof of Testing

Tested extensively by a well-known "Soong-type" synthetic intelligence and android-lifeform, **Lieutenant Commander Data**.

<summary>Screenshots/Videos</summary>
<details>

https://github.com/Floofies/NovaSector/assets/17753498/925a39d0-98e8-4a44-8a0b-fa909417a709

</details>

## Changelog

:cl:
add: Enabled the synth power cord implant to charge from any power cell. Renamed it to charging implant.
/:cl:
