### PR TITLE
Sizeplay: Refactors apply_to_human()

### DIFF
--- a/modular_nova/master_files/code/modules/client/preferences/body_size.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/body_size.dm
@@ -11,8 +11,7 @@
 	return passed_initial_check
 
 /datum/preference/numeric/body_size/apply_to_human(mob/living/carbon/human/target, value)
-	target.dna.features["body_size"] = value
-	target.current_size = value //BLUEMOON EDIT: whoever thought it would be funny to just directly manipulate the dna without using the proper helper proc should be shot, will come back and refactor this later to use resize()
+	target.adjust_height(value, 1) //BLUEMOON EDIT: Refactors this fucking nonsense to use my new helper proc; because manipulating DNA features is bad. 1 = RESIZE_SET in resize.dm
 
 /datum/preference/numeric/body_size/create_default_value()
 	return BODY_SIZE_NORMAL

--- a/modular_nova/modules_bluemoon/sizeplay/resize.dm
+++ b/modular_nova/modules_bluemoon/sizeplay/resize.dm
@@ -26,7 +26,7 @@
 				return
 			// Determine the required scaler to reach the target value
 			var/target_value = scaling_factor
-			// A bit nasty, but just pretend we passed in the correct arg :3
+			// A bit nasty, but just pretend we passed in the correct arg
 			scaling_factor = (target_value / current_size)
 
 	// update_transform scales it's current value relatively, so we can just pass in the argument directly.


### PR DESCRIPTION
## About The Pull Request

Changes apply_to_human() to use adjust_height() instead, because manipulating dna features is nasty business.

## Proof of Testing
![image](https://github.com/Floofies/NovaSector/assets/9637690/ab3d8bcb-849f-41b3-b061-5702ed82ab1d)
Characters spawned using select_equipment have proper offsets; characters spawned traditionaly do not if they have a scale above one; introduced as a result of how dna feature manipulations work, and my application of current_size.

## Changelog

:cl: Gonenoculer5
refactor: Changes apply_to_human() to use my adjust_height() proc instead, because it enforces pixel offsets.
/:cl: