### PR TITLE
More markings slots per limb! Was 3, now 4!

### DIFF
--- a/code/__DEFINES/~nova_defines/DNA.dm
+++ b/code/__DEFINES/~nova_defines/DNA.dm
@@ -61,7 +61,7 @@
 //Defines for an accessory to be randomed
 #define ACC_RANDOM		"random"
 
-#define MAXIMUM_MARKINGS_PER_LIMB 4 //BLUEMOON EDIT - MARKINGSLOTS - Increased from Nova's default 3, to allow a lsightly bigger range of character customisation.
+#define MAXIMUM_MARKINGS_PER_LIMB 4 // Bluemoon edit - MARKINGSLOTS - Increased from Nova's default 3, to allow a slightly bigger range of character customisation.
 
 #define BODY_SIZE_NORMAL 1.00
 #define BODY_SIZE_MAX 3.0 //BLUEMOON EDIT - SIZEPLAY - Increased to 3.0 to provide a wider array of size options in the editor. Heights above 18' must be achieved with Prospacillin.

--- a/code/__DEFINES/~nova_defines/DNA.dm
+++ b/code/__DEFINES/~nova_defines/DNA.dm
@@ -61,7 +61,7 @@
 //Defines for an accessory to be randomed
 #define ACC_RANDOM		"random"
 
-#define MAXIMUM_MARKINGS_PER_LIMB 3
+#define MAXIMUM_MARKINGS_PER_LIMB 4 //BLUEMOON EDIT - MARKINGSLOTS - Increased from Nova's default 3, to allow a lsightly bigger range of character customisation.
 
 #define BODY_SIZE_NORMAL 1.00
 #define BODY_SIZE_MAX 3.0 //BLUEMOON EDIT - SIZEPLAY - Increased to 3.0 to provide a wider array of size options in the editor. Heights above 18' must be achieved with Prospacillin.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin, in the commit, and in the comment to the change: increase the amount of maximum marking slots, by exactly 1.

The original intent was to increase the maximum slots to 5, but in testing, it was discovered that such breaks preferences and GAGS code for some unknown reason. 

## How This Contributes To The Blue Moon Roleplay Experience
It allows for slightly more character customisation, letting players add a tiny bit more to their character's sprite.


## Proof of Testing
It compiled, did not runtime the hell out (unlike testing for 5 marking slots), and allowed me to choose 4 markings per limb.


## Changelog
:cl:DevillishOne presents
:add: One more slot for your character's markings
/:cl: