### PR TITLE
Allows players to use gas miner beacons anywhere

### DIFF
--- a/modular_nova/modules/modular_items/code/summon_beacon.dm
+++ b/modular_nova/modules/modular_items/code/summon_beacon.dm
@@ -135,8 +135,9 @@
 	desc = "Once a gas miner type is selected, delivers a gas miner to the target location."
 
 	allowed_areas = list(
-		/area/station/engineering/atmos,
-		/area/station/engineering/atmospherics_engine,
+	//	/area/station/engineering/atmos,
+	//	/area/station/engineering/atmospherics_engine,
+		/area, // BLUEMOON EDIT - GasMinersAnywhere - Allows gas miner beacons to summon the gas miner anywhere! Might be a horrible idea on the coder's part.
 	)
 
 	selectable_atoms = list(
@@ -147,5 +148,5 @@
 		/obj/machinery/atmospherics/miner/plasma,
 	)
 
-	area_string = "atmospherics"
+	area_string = /*"atmospherics"*/ "any" // BLUEMOON EDIT - GasMinersAnywhere - Allows gas miner beacons to summon the gas miner anywhere! Might be a horrible idea on the coder's part.
 	supply_pod_stay = TRUE


### PR DESCRIPTION
## About The Pull Request
Like my previous PR, the title is self explanatory. It is just a small edit, with original values/restrictions commented out, to allow unrestricted deployment of gas miners. Colony builders, station restorators, and ship builders, rejoice!

## How This Contributes To The Blue Moon Roleplay Experience
It allows more fun and freedom for the players, as well as take the extra bit of time off admins, who'd have to search up the gas miners in the spawn objects menu to spawn them at request.

More player builds --> More places to RP in --> More fun!


## Proof of Testing
It compiled and did not blow up.
Besides, Places Where A Gas Miner Should Not Be In:
Meta Station Bridge
![image](https://github.com/user-attachments/assets/3b06a161-a5b1-4f43-bb24-35141d8ccb25)



## Changelog
:cl:DevillishOne presents
Unrestricted gas miners! In any place, provided you can afford them.
/:cl: