### PR TITLE
A chest-full of heart options

### DIFF
--- a/modular_nova/modules_bluemoon/augments_plus/code/organs_chest.dm
+++ b/modular_nova/modules_bluemoon/augments_plus/code/organs_chest.dm
@@ -17,3 +17,38 @@
 	name = "Upgraded Cybernetic Stomach"
 	path = /obj/item/organ/internal/stomach/cybernetic/tier3
 	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/demon
+	name = "Demonic Heart"
+	path = /obj/item/organ/internal/heart/demon
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/gland/access
+	name = "Anagraphic Electro-Scrambler"
+	path = /obj/item/organ/internal/heart/gland/access
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/gland/randoblood
+	name = "Pseudonuclear Hemo-Destabilizer"
+	path = /obj/item/organ/internal/heart/gland/blood
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/gland/chem
+	name = "Intrinsic Pharma-Provider"
+	path = /obj/item/organ/internal/heart/gland/chem
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/gland/heal
+	name = "Implant Rejecting Organic Replicator"
+	path = /obj/item/organ/internal/heart/gland/heal
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/gland/quantum
+	name = "Quantic De-Observation Matrix"
+	path = /obj/item/organ/internal/heart/gland/quantum
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC
+
+/datum/augment_item/organ/heart/gland/ventcrawling
+	name = "Pliant Cartilage Enabler"
+	path = /obj/item/organ/internal/heart/gland/ventcrawling
+	allowed_biotypes = MOB_ORGANIC | MOB_ROBOTIC


### PR DESCRIPTION
## About The Pull Request
Another small addition of mine.
This one lets people choose a demon heart, as well as some of the abductor glands in Augments+ tab of character preferences.
Not all of them were made available because some are actively harmful to everyone around, like the mindshock, electrical, and plasma ones, or additionally harmful to the server itself (Insert here: an image of an idle character with a spider/slime abductor gland morphing into a mob spawner from Minecraft).

## How This Contributes To The Blue Moon Roleplay Experience
More fun things to use and RP about!

## Proof of Testing
Compiled, ran, and...
![image](https://github.com/user-attachments/assets/34ebe7ed-51ed-42ad-919e-07d422f103ec)
Worked.

## Changelog
:cl:DevillishOne presents
A higher range of hearts to choose in the Augments+ tab.
/:cl: