### PR TITLE
Fixes boob overlays & Loadouts

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/genitals.dm
@@ -513,7 +513,8 @@
 
 /datum/bodypart_overlay/mutant/genital/breasts
 	feature_key = ORGAN_SLOT_BREASTS
-	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND
+	layers = EXTERNAL_FRONT_UNDER_CLOTHES | EXTERNAL_BEHIND | SHOES_LAYER //BLUEMOON EDIT: The fact that this is necessary makes me want to off myself. Don't remove the shoes layer thing unless your making a permenant fix. Otherwise hands appear over tits. Not bueno.
+
 
 /datum/bodypart_overlay/mutant/genital/breasts/underwear_check()
 	if(!istype(owner))

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_accessory.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_accessory.dm
@@ -5,7 +5,7 @@
 /// Accessory Items (Moves overrided items to backpack)
 /datum/loadout_category/accessories
 	category_ui_icon = FA_ICON_ID_BADGE
-	tab_order = /datum/loadout_category/undersuit::tab_order + 1
+	tab_order = /datum/loadout_category/head::tab_order + 3
 
 
 /datum/loadout_item/accessory/pre_equip_item(datum/outfit/outfit, datum/outfit/outfit_important_for_life, visuals_only = FALSE)

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_inhands.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_inhands.dm
@@ -1,6 +1,6 @@
 // LOADOUT ITEM DATUMS FOR BOTH HAND SLOTS
 /datum/loadout_category/inhands
-	tab_order = /datum/loadout_category/feet::tab_order + 1
+	tab_order = /datum/loadout_category/head::tab_order + 4
 
 /datum/loadout_item/inhand/pre_equip_item(datum/outfit/outfit, datum/outfit/outfit_important_for_life, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	// if no hands are available then put in backpack

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -1,6 +1,6 @@
 // LOADOUT ITEM DATUMS FOR THE NECK SLOT
 /datum/loadout_category/neck
-	tab_order = /datum/loadout_category/ears::tab_order + 1
+	tab_order = /datum/loadout_category/head::tab_order + 2
 
 /datum/loadout_item/neck/pre_equip_item(datum/outfit/outfit, datum/outfit/outfit_important_for_life, mob/living/carbon/human/equipper, visuals_only = FALSE)
 	if(initial(outfit_important_for_life.neck))

--- a/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_nova/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -1,5 +1,5 @@
 /datum/loadout_category/pocket
-	tab_order = /datum/loadout_category/toys::tab_order + 1
+	tab_order = /datum/loadout_category/head::tab_order + 5
 
 /datum/loadout_item/pocket_items/pre_equip_item(datum/outfit/outfit, datum/outfit/outfit_important_for_life, mob/living/carbon/human/equipper, visuals_only = FALSE) // these go in the backpack
 	return FALSE


### PR DESCRIPTION
Fixes an issue with boob layering by stapling them to your shoes. Yes, I'm serious.

Also fixes a weird layout order for loadouts; and brings parity into the order with Nova.

I investigated fixing the second half of #44 ; but unfortunately it seems that Teshari need to have a custom offset set. Verified that genitals work perfectly fine for every other species, oddly enough including dwarves. Not entirely sure how else to fix Teshari genitals being one pixel to the left; and about ten higher than they should be for breasts other than somehow giving them a unique offset when put into a teshari. I shall leave that to a wiser man than I.